### PR TITLE
Support additional javascript on initialisation

### DIFF
--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -6,6 +6,7 @@
  */
 namespace dosamigos\ckeditor;
 
+use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
 use yii\helpers\Json;
 use yii\widgets\InputWidget;
@@ -48,7 +49,7 @@ class CKEditor extends InputWidget
      * Registers CKEditor plugin
      * @codeCoverageIgnore
      */
-    protected function registerPlugin()
+    protected function registerPlugin(array $jsPre = [], array $jsPost = [])
     {
         $js = [];
 
@@ -69,6 +70,6 @@ class CKEditor extends InputWidget
             $js[] = "dosamigos.ckEditorWidget.registerCsrfImageUploadHandler();";
         }
 
-        $view->registerJs(implode("\n", $js));
+        $view->registerJs(implode("\n", ArrayHelper::merge($jsPre, $js, $jsPost)));
     }
 }

--- a/src/CKEditorInline.php
+++ b/src/CKEditorInline.php
@@ -7,6 +7,7 @@
 namespace dosamigos\ckeditor;
 
 use yii\base\Widget;
+use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
 use yii\helpers\Json;
 
@@ -68,7 +69,7 @@ class CKEditorInline extends Widget
      * Registers CKEditor plugin
      * @codeCoverageIgnore
      */
-    protected function registerPlugin()
+    protected function registerPlugin(array $jsPre = [], array $jsPost = [])
     {
         $js = [];
 
@@ -91,6 +92,6 @@ class CKEditorInline extends Widget
             $js[] = "dosamigos.ckEditorWidget.registerCsrfImageUploadHandler();";
         }
 
-        $view->registerJs(implode("\n", $js));
+        $view->registerJs(implode("\n", ArrayHelper::merge($jsPre, $js, $jsPost)));
     }
 }


### PR DESCRIPTION
Hi and thx for the module.

However I wanted to change CKEDITOR.timestamp to remove all those query strings from CKEditors css file loading. I ended up copy and paste the whole registerPlugin function inside my child class of CKEditor to insert the javascript at the right place.
I think it would be better to give others the possibility to add more javascript while the plugin is registered. 
Please have a look at my additions. You now could extend CKEditior and just adjust call of parent::registerPlugin()