### PR TITLE
CsrfImageUploadHandler isn't always registered, causing problems

### DIFF
--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -65,7 +65,7 @@ class CKEditor extends InputWidget
         $js[] = "CKEDITOR.replace('$id', $options);";
         $js[] = "dosamigos.ckEditorWidget.registerOnChangeHandler('$id');";
 
-        if (isset($this->clientOptions['filebrowserUploadUrl'])) {
+        if (isset($this->clientOptions['filebrowserUploadUrl']) || isset($this->clientOptions['filebrowserImageUploadUrl'])) {
             $js[] = "dosamigos.ckEditorWidget.registerCsrfImageUploadHandler();";
         }
 


### PR DESCRIPTION
The CKEditor file browser can open different dialogs depending on whether a generic file browse / upload function is required or a specific image browse / upload function. The original code is configured to only include the CSRF code if the generic file upload 'filebrowserUploadUrl' option is provided.  However, it is possible for someone to specifically use the 'filebrowserImageUploadUrl' option without the other one; this results in the CSRF code not being registered.  By checking for either option being defined, the CSRF code is always included when at least one of the options is required.