### PR TITLE
replace click event by native

### DIFF
--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -65,9 +65,7 @@ class CKEditor extends InputWidget
         $js[] = "CKEDITOR.replace('$id', $options);";
         $js[] = "dosamigos.ckEditorWidget.registerOnChangeHandler('$id');";
 
-        if (isset($this->clientOptions['filebrowserUploadUrl']) || isset($this->clientOptions['filebrowserImageUploadUrl'])) {
-            $js[] = "dosamigos.ckEditorWidget.registerCsrfImageUploadHandler();";
-        }
+		$js[] = "dosamigos.ckEditorWidget.registerCsrfUploadHandler('$id');";
 
         $view->registerJs(implode("\n", $js));
     }

--- a/src/CKEditorWidgetAsset.php
+++ b/src/CKEditorWidgetAsset.php
@@ -18,7 +18,7 @@ use yii\web\AssetBundle;
  */
 class CKEditorWidgetAsset extends AssetBundle
 {
-    public $sourcePath = 'assets';
+    public $sourcePath = '@dosamigos/ckeditor/assets';
 
     public $depends = [
         'dosamigos\ckeditor\CKEditorAsset'

--- a/src/assets/dosamigos-ckeditor.widget.js
+++ b/src/assets/dosamigos-ckeditor.widget.js
@@ -17,21 +17,14 @@ dosamigos.ckEditorWidget = (function ($) {
                 return false;
             });
         },
-        registerCsrfImageUploadHandler: function () {
-            yii & $(document).off('click', '.cke_dialog_tabs a[id^="cke_Upload_"]').on('click', '.cke_dialog_tabs a[id^="cke_Upload_"]', function () {
-                var $forms = $('.cke_dialog_ui_input_file iframe').contents().find('form');
-                var csrfName = yii.getCsrfParam();
-                $forms.each(function () {
-                    if (!$(this).find('input[name=' + csrfName + ']').length) {
-                        var csrfTokenInput = $('<input/>').attr({
-                            'type': 'hidden',
-                            'name': csrfName
-                        }).val(yii.getCsrfToken());
-                        $(this).append(csrfTokenInput);
-                    }
-                });
-            });
-        }
+		registerCsrfUploadHandler: function (id) {
+			CKEDITOR && CKEDITOR.instances[id] && CKEDITOR.instances[id].on('fileUploadRequest', function (evt) {
+				var csrfName = yii.getCsrfParam();
+				var csrfToken = $($(CKEDITOR.instances[id].element.$.form).find('input[name=' + csrfName + ']')[0]).val();
+				var xhr = evt.data.fileLoader.xhr;
+				xhr.setRequestHeader('X-CSRF-Token', csrfToken);
+			});
+		},
     };
     return pub;
 })(jQuery);


### PR DESCRIPTION
Before, csrf token added to post request only when "filebrowserUploadUrl" or "filebrowserImageUploadUrl" has been set in clientOptions. But if you use dropped or pasted upload, csrf token not apply to post request.
I think "click" event can be replaced by native "fileUploadRequest" event. After this csrf will be added to any upload actions of CKEditor.

Also, i fixed miss alias path to dosamigos-ckeditor.widget.js
