### PR TITLE
Change CKEditor version to allow use standard and full version CKEditor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "yiisoft/yii2": "^2.0",
-        "ckeditor/ckeditor": "^4.7",
+        "ckeditor/ckeditor": "^4.7 || dev-full/4.11.x",
         "sunhater/kcfinder": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Default instalation use standard version "ckeditor/ckeditor": "^4.7"

For use full version CKEditor add followed line to required section
"ckeditor/ckeditor": "dev-full/4.11.x",